### PR TITLE
Install dokuwiki tools namespace

### DIFF
--- a/part-03/README.md
+++ b/part-03/README.md
@@ -59,7 +59,7 @@ Update Complete. ⎈ Happy Helming!⎈
 Let try the Helming:
 
 ```
-helm install --name wiki stable/dokuwiki
+helm install --namespace tools --name wiki stable/dokuwiki
 ```
 
 ```


### PR DESCRIPTION
Right now, it runs(?) dokuwiki in the `default` namespace when it should run it in the `tools` namespace according to the `kubectl -n tools get pods -o wide` command.